### PR TITLE
Disable pushing benchmarks

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -328,6 +328,15 @@ jobs:
           mkdir -p benchmarks
           ./dist/benchmarks benchmarks/data.json output.json
 
+      - name: Upload results
+        uses: actions/upload-artifact@v4 # v4
+        with:
+          name: final-benchmark-results
+          path: benchmarks/*.json
+
+      - name: push results
+        if: false # disabling for now
+        run: |
           git config --global user.name 'mheffner'
           git config --global user.email 'mheffner@users.noreply.github.com'
           


### PR DESCRIPTION
Upload the results so that we can check them in the artifacts, but disable pushing for now until we've settled the fluentbit changes.

